### PR TITLE
Fehlende Übersetzungen

### DIFF
--- a/email/emergency_access_invite_confirmed.hbs
+++ b/email/emergency_access_invite_confirmed.hbs
@@ -1,6 +1,6 @@
 Notfallkontakt für {{{grantor_name}}} bestätigt
 <!---------------->
-Mit dieser E-Mail informieren wir dich, dass du als Notfallkontakt für *{{Grantor_name}}* bestätig wurdest.
+Mit dieser E-Mail informieren wir dich, dass du als Notfallkontakt für *{{grantor_name}}* bestätig wurdest.
 
 Du kannst jetzt Notfallzugriffsanfragen vom Web-Tresor ({{url}}) aus starten.
 {{> email/email_footer_text }}

--- a/email/invite_accepted.html.hbs
+++ b/email/invite_accepted.html.hbs
@@ -4,7 +4,7 @@ Einladung zu {{{org_name}}} angenommen
 <table width="100%" cellpadding="0" cellspacing="0" style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
    <tr style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
       <td class="content-block" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; margin: 0; -webkit-font-smoothing: antialiased; padding: 0 0 10px; -webkit-text-size-adjust: none;" valign="top">
-         This email is to notify you that {{email}} has accepted your invitation to join <b style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">{{org_name}}</b>.
+         Mit dieser E-Mail teilen wir dir mit, dass {{email}} deine Einladung zur Mitgliedschaft angenommen hat <b style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">{{org_name}}</b>.
       </td>
    </tr>
    <tr style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">

--- a/email/pw_hint_some.hbs
+++ b/email/pw_hint_some.hbs
@@ -2,7 +2,7 @@ Dein Master-Passwort-Hinweis
 <!---------------->
 Du (oder jemand anderes) hat vor kurzem deinen Master-Passwort-Hinweis angefordert.
 
-Dein Hinweis ist: *{{Hinweis}}*
+Dein Hinweis ist: *{{hint}}*
 Im Web-Tresor anmelden: {{url}}
 
 Wenn du dich nicht mehr an dein Master-Passwort erinnern kannst, gibt es keine Möglichkeit deine Daten wiederherzustellen. Die einzige Möglichkeit wieder Zugang zu deinem Konto zu erhalten ist das Konto zu löschen ( {{url}}/#/recover-delete ), damit du dich erneut registrieren und von vorne beginnen kannst. Alle Daten, die mit deinem Konto verbunden sind, werden gelöscht.

--- a/email/send_2fa_removed_from_org.hbs
+++ b/email/send_2fa_removed_from_org.hbs
@@ -1,6 +1,6 @@
 Entfernt aus {{{org_name}}}
 <!---------------->
-Du wurdest aus der Organisation *{{Organisationsname}}* entfernt, weil in deinem Konto die Zwei-Faktor-Authentifizierung nicht aktiviert ist.
+Du wurdest aus der Organisation *{{org_name}}* entfernt, weil in deinem Konto die Zwei-Faktor-Authentifizierung nicht aktiviert ist.
 
 
 Du kannst die Zwei-Faktor-Authentifizierung in deinen Kontoeinstellungen aktivieren.


### PR DESCRIPTION
Moin,

ich habe ein paar Fehler korrigiert. Einer hat dazu geführt, dass Nutzer keine Passwort-Hinweis Mails mehr anfordern konnten. Dabei sind mir dann noch weitere aufgefallen.